### PR TITLE
Handle new message file name

### DIFF
--- a/src/Command/GoogleTranslateCommand.php
+++ b/src/Command/GoogleTranslateCommand.php
@@ -125,7 +125,8 @@ class GoogleTranslateCommand extends Command
         foreach ($translationFiles as $translationFile)
         {
             $ext = $translationFile->getExtension();
-            $domain = explode('.', $translationFile->getFilename())[0];
+            // $domain = explode('.', $translationFile->getFilename())[0];
+            $domain = $this->getDomainName( $translationFile->getFilename());
             $fileLoader = FileLoaderFactory::createFromExtension($ext);
             $messages = $fileLoader->load($translationFile->getRealPath(), $sourceLocale, $domain)->all();
 
@@ -178,4 +179,16 @@ class GoogleTranslateCommand extends Command
 
         return 0;
     }
+
+    /**
+     * 
+     */
+    protected function getDomainName(string $fileName): string
+    {
+        // Explode
+        $domain = explode('.', $fileName)[0];
+        // Replace
+        return str_replace(MessageCatalogue::INTL_DOMAIN_SUFFIX, '', $domain);
+    }
+    
 }


### PR DESCRIPTION
Hi,

The symfony translation:update command generate file with a constant to manage ICU Message format (+intl-icu) which is not present in domain name. As google-translate command used the filename to get domain name, it's not working. The command does not find domain.

I add a very simple workaround but there is maybe a better way ...

Links : 
* https://symfony.com/doc/current/translation.html#extracting-translation-contents-and-updating-catalogs-automatically
* https://symfony.com/doc/current/translation/message_format.html#using-the-icu-message-format

